### PR TITLE
Create spawn positions closes #17

### DIFF
--- a/Assets/Scripts/MatchController/SpawnController.cs
+++ b/Assets/Scripts/MatchController/SpawnController.cs
@@ -30,26 +30,26 @@ namespace MatchController
         private void Start()
         {
             blue_spawn_points.Add(new SpawnLocation(-20.48f,  0.0f, -25.6f, 45));
-            blue_spawn_points.Add(new SpawnLocation(20.48f, 0.0f, -25.6f, 135));
-            blue_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, -38.4f, 90));
-            blue_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, -38.4f, 90));
-            blue_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, -46.08f, 90));
+            blue_spawn_points.Add(new SpawnLocation(20.48f, 0.0f, -25.6f, -45));
+            blue_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, -38.4f, 0));
+            blue_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, -38.4f, 0));
+            blue_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, -46.08f, 0));
             
-            orange_spawn_points.Add(new SpawnLocation(20.48f,  0.0f, 25.6f, 135));
-            orange_spawn_points.Add(new SpawnLocation(-20.48f, 0.0f, 25.6f, -45));
-            orange_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, 38.4f, -90));
-            orange_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, 38.4f, -90));
-            orange_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, 46.08f, -90));
+            orange_spawn_points.Add(new SpawnLocation(20.48f,  0.0f, 25.6f, 225));
+            orange_spawn_points.Add(new SpawnLocation(-20.48f, 0.0f, 25.6f, 135));
+            orange_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, 38.4f, 180));
+            orange_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, 38.4f, 180));
+            orange_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, 46.08f, 180));
             
-            blue_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, -46.08f, 90));
-            blue_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, -46.08f, 90));
-            blue_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, -46.08f, 90));
-            blue_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, -46.08f, 90));
+            blue_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, -46.08f, 0));
+            blue_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, -46.08f, 0));
+            blue_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, -46.08f, 0));
+            blue_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, -46.08f, 0));
             
-            orange_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, -46.08f, 90));
-            orange_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, -46.08f, 90));
-            orange_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, -46.08f, 90));
-            orange_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, -46.08f, 90));
+            orange_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, 46.08f, 180));
+            orange_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, 46.08f, 180));
+            orange_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, 46.08f, 180));
+            orange_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, 46.08f, 180));
         }
 
         public SpawnLocation GetSpawnPosition(int team)
@@ -77,7 +77,16 @@ namespace MatchController
 
             return spawn_points[idx];
         }
-        
-        
+
+        public GameObject SpawnCar(GameObject car, bool was_demolished = false)
+        {
+            // we do not know how teams are implemented
+            // team = car.transform.Find("Team").team;
+            int team = 0;
+            SpawnLocation spawnLocation = was_demolished ? GetDemolitionSpawnPosition(team) : GetSpawnPosition(team);
+            car.transform.localPosition = spawnLocation.location;
+            car.transform.localRotation = spawnLocation.orientation;
+            return car;
+        }
     }
 }

--- a/Assets/Scripts/MatchController/SpawnController.cs
+++ b/Assets/Scripts/MatchController/SpawnController.cs
@@ -12,7 +12,7 @@ namespace MatchController
         {
             location = new Vector3(x, y, z);
             orientation = Quaternion.AngleAxis(yaw, Vector3.up);
-            last_used = 0.0f;
+            last_used = float.NegativeInfinity;
         }
             
         public Vector3 location;
@@ -57,7 +57,7 @@ namespace MatchController
             List<SpawnLocation> spawn_points = team == 0 ? orange_spawn_points : blue_spawn_points;
             
             int idx = Random.Range(0,4);
-            while (spawn_points[idx].last_used > 10.0f)
+            while (Time.time - spawn_points[idx].last_used < 5.0f)
             {
                 idx++;
             }
@@ -70,7 +70,7 @@ namespace MatchController
             List<SpawnLocation> spawn_points = team == 0 ? orange_demolition_spawn_points : blue_demolition_spawn_points;
             
             int idx = Random.Range(0, 3);
-            while (spawn_points[idx].last_used > 10.0f)
+            while (Time.time - spawn_points[idx].last_used < 5.0f)
             {
                 idx++;
             }

--- a/Assets/Scripts/MatchController/SpawnController.cs
+++ b/Assets/Scripts/MatchController/SpawnController.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using Random = UnityEngine.Random;
+
+namespace MatchController
+{
+    public struct SpawnLocation
+    {
+        public SpawnLocation(float x, float y, float z, float yaw)
+        {
+            location = new Vector3(x, y, z);
+            orientation = Quaternion.AngleAxis(yaw, Vector3.up);
+            last_used = 0.0f;
+        }
+            
+        public Vector3 location;
+        public Quaternion orientation;
+        public float last_used;
+    }
+    
+    public class SpawnController : MonoBehaviour
+    {
+        List<SpawnLocation> blue_spawn_points = new List<SpawnLocation>();
+        List<SpawnLocation> orange_spawn_points = new List<SpawnLocation>();
+        List<SpawnLocation> blue_demolition_spawn_points = new List<SpawnLocation>();
+        List<SpawnLocation> orange_demolition_spawn_points = new List<SpawnLocation>();
+
+        private void Start()
+        {
+            blue_spawn_points.Add(new SpawnLocation(-20.48f,  0.0f, -25.6f, 45));
+            blue_spawn_points.Add(new SpawnLocation(20.48f, 0.0f, -25.6f, 135));
+            blue_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, -38.4f, 90));
+            blue_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, -38.4f, 90));
+            blue_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, -46.08f, 90));
+            
+            orange_spawn_points.Add(new SpawnLocation(20.48f,  0.0f, 25.6f, 135));
+            orange_spawn_points.Add(new SpawnLocation(-20.48f, 0.0f, 25.6f, -45));
+            orange_spawn_points.Add(new SpawnLocation(2.56f, 0.0f, 38.4f, -90));
+            orange_spawn_points.Add(new SpawnLocation(-2.56f, 0.0f, 38.4f, -90));
+            orange_spawn_points.Add(new SpawnLocation(0.0f, 0.0f, 46.08f, -90));
+            
+            blue_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, -46.08f, 90));
+            blue_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, -46.08f, 90));
+            blue_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, -46.08f, 90));
+            blue_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, -46.08f, 90));
+            
+            orange_demolition_spawn_points.Add(new SpawnLocation(-23.04f, 0.0f, -46.08f, 90));
+            orange_demolition_spawn_points.Add(new SpawnLocation(-26.88f, 0.0f, -46.08f, 90));
+            orange_demolition_spawn_points.Add(new SpawnLocation(23.04f, 0.0f, -46.08f, 90));
+            orange_demolition_spawn_points.Add(new SpawnLocation(26.88f, 0.0f, -46.08f, 90));
+        }
+
+        public SpawnLocation GetSpawnPosition(int team)
+        {
+            List<SpawnLocation> spawn_points = team == 0 ? orange_spawn_points : blue_spawn_points;
+            
+            int idx = Random.Range(0,4);
+            while (spawn_points[idx].last_used > 10.0f)
+            {
+                idx++;
+            }
+
+            return spawn_points[idx];
+        }
+        
+        public SpawnLocation GetDemolitionSpawnPosition(int team)
+        {
+            List<SpawnLocation> spawn_points = team == 0 ? orange_demolition_spawn_points : blue_demolition_spawn_points;
+            
+            int idx = Random.Range(0, 3);
+            while (spawn_points[idx].last_used > 10.0f)
+            {
+                idx++;
+            }
+
+            return spawn_points[idx];
+        }
+        
+        
+    }
+}

--- a/Assets/Scripts/MatchController/SpawnController.cs.meta
+++ b/Assets/Scripts/MatchController/SpawnController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 73be25fa26c645ecb890cb2265219c2a
+timeCreated: 1623084271


### PR DESCRIPTION
Spawn positions can be obtained and a car can be respawned at one of five designated spawn locations for each team or in case of a demolition at one of four demolition spawn points.