### PR TITLE
Refined Boostpad behavior

### DIFF
--- a/Assets/Prefabs/BigBoostpad.prefab
+++ b/Assets/Prefabs/BigBoostpad.prefab
@@ -172,6 +172,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2546091910606873564}
   - component: {fileID: 2546091910606873565}
+  - component: {fileID: 6024545753295589698}
+  - component: {fileID: 6627563549871094405}
   m_Layer: 0
   m_Name: BigBoostpad
   m_TagString: Boostpad
@@ -212,3 +214,32 @@ MonoBehaviour:
   height: 1.68
   radius: 2.08
   isBig: 1
+--- !u!65 &6024545753295589698
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2546091910606873567}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 3.2, y: 2.6, z: 3.2}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6627563549871094405
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2546091910606873567}
+  serializedVersion: 2
+  m_Mass: 0.0000001
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0

--- a/Assets/Prefabs/SmallBoostpad.prefab
+++ b/Assets/Prefabs/SmallBoostpad.prefab
@@ -91,6 +91,8 @@ GameObject:
   m_Component:
   - component: {fileID: 3199678786225046926}
   - component: {fileID: 1552186393681501274}
+  - component: {fileID: 2274185639522818106}
+  - component: {fileID: 7619022283538462382}
   m_Layer: 0
   m_Name: SmallBoostpad
   m_TagString: Boostpad
@@ -130,3 +132,32 @@ MonoBehaviour:
   height: 1.65
   radius: 1.44
   isBig: 0
+--- !u!65 &2274185639522818106
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199678786225046925}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1.92, y: 2.6, z: 1.92}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &7619022283538462382
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3199678786225046925}
+  serializedVersion: 2
+  m_Mass: 0.0000001
+  m_Drag: 0
+  m_AngularDrag: 0
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0

--- a/Assets/Scenes/Test.unity
+++ b/Assets/Scenes/Test.unity
@@ -286,7 +286,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1733474344396911142, guid: a53d74f7692c3fb4d95003d2a3de5630, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.19
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1733474344396911142, guid: a53d74f7692c3fb4d95003d2a3de5630, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scripts/Boostpad.cs
+++ b/Assets/Scripts/Boostpad.cs
@@ -17,14 +17,39 @@ public class Boostpad : MonoBehaviour
 
     private Renderer _rend;
 
+    private BoxCollider _hitbox;
+
+    private Dictionary<GameObject, float> _carsInRadius;
+
     void Start()
     {
         _rend = transform.GetChild(0).GetComponent<Renderer>();
+        _hitbox = transform.GetComponent<BoxCollider>();
+        _carsInRadius = new Dictionary<GameObject, float>();
     }
 
 
     void Update()
     {
+        GameObject[] cars = GameObject.FindGameObjectsWithTag("ControllableCar");
+        foreach (GameObject car in cars)
+        {
+            Vector3 relativePosition = gameObject.transform.position - car.transform.position;
+            float dist = new Vector2(relativePosition.x, relativePosition.z).magnitude;
+            float relativeHeight = Mathf.Abs(relativePosition.y);
+            if (_carsInRadius.ContainsKey(car))
+            {
+                _carsInRadius[car] = dist;
+            }
+            else
+            {
+                if (relativeHeight <= height && dist <= radius)
+                {
+                    _carsInRadius.Add(car, dist);
+                }
+            }
+        }
+
         if (!_isActive)
         {
             _rend.material.SetColor("_Color", Color.black);
@@ -45,34 +70,45 @@ public class Boostpad : MonoBehaviour
             {
                 transform.GetChild(1).gameObject.SetActive(true);
             }
-
-            GameObject[] cars = GameObject.FindGameObjectsWithTag("ControllableCar");
-            
-            foreach (GameObject car in cars)
+            if (_carsInRadius.Keys.Count > 0)
             {
-                Vector3 relativePosition = gameObject.transform.position - car.transform.position;
-                float dist = new Vector2(relativePosition.x, relativePosition.z).magnitude;
-                float relativeHeight = Mathf.Abs(relativePosition.y);
-                if (relativeHeight <= height && dist <= radius)
-                {
-                    if (_isActive) {
-                        var cube = car.GetComponentInChildren<CubeBoosting>();
-                        Debug.Log(cube);
-                        bool isBoostFull = cube.IncreaseBoost(boostAmount); //IncreaseBoost returns true, if boost was already at 100
-                        if (!isBoostFull)
-                        {
-                            PickUpBoost();
-                        }
-                    }
-                }
+                PickUpBoost(getFurthestCarInRadius());
             }
-            
         }
     }
 
-    private void PickUpBoost()
+    private void OnTriggerExit(Collider other)
     {
-        _lastPickup = Time.time;
-        _isActive = false;
+        if (other.gameObject.CompareTag("BodyCollider"))
+        {
+            _carsInRadius.Remove(other.GetComponentInParent<Rigidbody>().gameObject);
+        }
+    }
+
+    private GameObject getFurthestCarInRadius()
+    {
+        GameObject furthestCar = null;
+        float maxDist = 0f;
+        foreach (KeyValuePair<GameObject, float> carDist in _carsInRadius)
+        {
+            if (carDist.Value > maxDist)
+            {
+                furthestCar = carDist.Key;
+                maxDist = carDist.Value;
+            }
+        }
+        return furthestCar;
+    }
+
+    private void PickUpBoost(GameObject car)
+    {
+        var cube = car.GetComponentInChildren<CubeBoosting>();
+        bool isBoostFull = cube.IncreaseBoost(boostAmount); //IncreaseBoost returns true, if boost was already at 100
+        if (!isBoostFull)
+        {
+            _lastPickup = Time.time;
+            _isActive = false;
+        }
+       
     }
 }

--- a/Assets/Scripts/Boostpad.cs
+++ b/Assets/Scripts/Boostpad.cs
@@ -15,6 +15,8 @@ public class Boostpad : MonoBehaviour
 
     public bool isBig = false;
 
+    private GameObject[] _cars;
+
     private Renderer _rend;
 
     private BoxCollider _hitbox;
@@ -26,13 +28,14 @@ public class Boostpad : MonoBehaviour
         _rend = transform.GetChild(0).GetComponent<Renderer>();
         _hitbox = transform.GetComponent<BoxCollider>();
         _carsInRadius = new Dictionary<GameObject, float>();
+        _cars = GameObject.FindGameObjectsWithTag("ControllableCar");
     }
 
 
     void Update()
     {
-        GameObject[] cars = GameObject.FindGameObjectsWithTag("ControllableCar");
-        foreach (GameObject car in cars)
+        
+        foreach (GameObject car in _cars)
         {
             Vector3 relativePosition = gameObject.transform.position - car.transform.position;
             float dist = new Vector2(relativePosition.x, relativePosition.z).magnitude;

--- a/Assets/Scripts/CarControllers/CubeController/CubeSphereCollider.cs
+++ b/Assets/Scripts/CarControllers/CubeController/CubeSphereCollider.cs
@@ -94,4 +94,5 @@ public class CubeSphereCollider : MonoBehaviour
         // Draw vertical line as ground hit indicators         
         Gizmos.DrawLine(transform.position, transform.position + transform.up * 0.5f);
     }
+    
 }


### PR DESCRIPTION
Boostpads now behave more like in RocketLeague, as they now register cars leaving the pad by a BoxCollider instead of the cylinder used to register cars entering the boostpad. They should also now correctly handle the case of multiple cars on the same boostpad (not tested).

[Rocket Science Boostpads](https://youtu.be/xgfa-qZyInw?t=24)